### PR TITLE
feat(t430): boot installed linux from genode vm

### DIFF
--- a/projects/t430/GENODE/config/22.10/launcher/vm
+++ b/projects/t430/GENODE/config/22.10/launcher/vm
@@ -1,5 +1,19 @@
-<launcher name="vbox6" pkg="genodelabs/pkg/vbox6/2022-10-13" priority="-2">
+<launcher name="vbox6" pkg="local/pkg/vbox6/2022-10-13" priority="-2">
 		<route>
+
+     <service name="Block" label_suffix=" -> 1">
+       <child name="ahci-0.part_block" label="1"/>
+     </service>
+     <service name="Block" label_suffix=" -> 4">
+       <child name="ahci-0.part_block" label="4"/>
+     </service>
+     <service name="Block" label_suffix=" -> 5">
+       <child name="ahci-0.part_block" label="5"/>
+     </service>
+     <service name="Block" label_suffix=" -> 6">
+       <child name="ahci-0.part_block" label="6"/>
+     </service>
+
 			<service name="File_system" label="vm">
 				<child name="vm_fs"/>
 			</service>

--- a/projects/t430/GENODE/depot/local/pkg/vbox6/2022-10-13/README
+++ b/projects/t430/GENODE/depot/local/pkg/vbox6/2022-10-13/README
@@ -1,0 +1,2 @@
+
+      VirtualBox runtime for hosting a large VM in the Sculpt scenario

--- a/projects/t430/GENODE/depot/local/pkg/vbox6/2022-10-13/archives
+++ b/projects/t430/GENODE/depot/local/pkg/vbox6/2022-10-13/archives
@@ -1,4 +1,4 @@
-genodelabs/raw/vbox6/2022-04-27
+local/raw/vbox6/2022-04-27
 genodelabs/src/expat/2022-10-11
 genodelabs/src/init/2022-10-11
 genodelabs/src/jpeg/2022-09-20

--- a/projects/t430/GENODE/depot/local/pkg/vbox6/2022-10-13/archives
+++ b/projects/t430/GENODE/depot/local/pkg/vbox6/2022-10-13/archives
@@ -1,0 +1,17 @@
+genodelabs/raw/vbox6/2022-04-27
+genodelabs/src/expat/2022-10-11
+genodelabs/src/init/2022-10-11
+genodelabs/src/jpeg/2022-09-20
+genodelabs/src/libc/2022-10-13
+genodelabs/src/libdrm/2022-10-11
+genodelabs/src/libiconv/2022-09-20
+genodelabs/src/libyuv/2022-09-20
+genodelabs/src/mesa/2022-10-11
+genodelabs/src/posix/2022-10-11
+genodelabs/src/stdcxx/2022-09-20
+genodelabs/src/vbox6/2022-10-11
+genodelabs/src/vfs/2022-10-11
+genodelabs/src/vfs_gpu/2022-10-11
+genodelabs/src/vfs_oss/2022-10-11
+genodelabs/src/vfs_pipe/2022-10-11
+genodelabs/src/zlib/2022-09-20

--- a/projects/t430/GENODE/depot/local/pkg/vbox6/2022-10-13/runtime
+++ b/projects/t430/GENODE/depot/local/pkg/vbox6/2022-10-13/runtime
@@ -1,0 +1,126 @@
+<runtime ram="4300M" caps="8000" binary="init">
+
+	<requires>
+		<file_system label="vm"/>
+		<file_system label="shared"/>
+		<vm/>
+		<timer/>
+		<gpu/>
+		<gui/>
+		<nic/>
+		<rom label="capslock"/>
+		<rom label="platform_info"/>
+		<report label="shape"/>
+		<report label="clipboard"/>
+		<rom    label="clipboard"/>
+		<rom label="mesa_gpu_drv.lib.so"/>
+		<rm/>
+		<rtc/>
+		<rom label="usb_devices"/>
+		<usb/>
+		<audio_out/>
+		<audio_in/>
+	</requires>
+
+	<config verbose="yes">
+
+		<parent-provides>
+			<service name="ROM"/>
+			<service name="PD"/>
+			<service name="RM"/>
+			<service name="CPU"/>
+			<service name="LOG"/>
+			<service name="VM"/>
+			<service name="Gui"/>
+			<service name="Gpu"/>
+			<service name="Timer"/>
+			<service name="Rtc"/>
+			<service name="Report"/>
+			<service name="File_system"/>
+			<service name="Usb"/>
+			<service name="Nic"/>
+			<service name="Audio_out"/>
+			<service name="Audio_in"/>
+		</parent-provides>
+
+		<default-route> <any-service> <parent/> <any-child/> </any-service> </default-route>
+
+		<default caps="100"/>
+
+		<start name="vbox" caps="7000">
+			<binary name="virtualbox6" />
+			<resource name="RAM" quantum="8G"/>
+			<exit propagate="yes"/>
+			<config vbox_file="machine.vbox6" xhci="yes" vm_name="linux" capslock="rom" ld_verbose="yes">
+				<vfs>
+					<dir name="dev">
+						<log/> <rtc/> <null/> <gpu/> <zero/> <oss name="dsp"/>
+					</dir>
+					<dir name="pipe"> <pipe/> </dir>
+					<dir name="shared"> <fs label="shared" writeable="yes"/> </dir>
+					<rom name="VBoxSharedClipboard.so"/>
+					<rom name="VBoxSharedFolders.so"/>
+					<fs writeable="yes"/>
+				</vfs>
+				<libc stdout="/dev/log" stderr="/dev/log" rtc="/dev/rtc" pipe="/pipe">
+					<pthread placement="single-cpu"/>
+				</libc>
+				<arg value="virtualbox"/>
+				<env key="VBOX_USER_HOME" value="/"/>
+				<env key="VBOX_LOG_DEST"          value="file=/dev/log"/>
+				<env key="VBOX_LOG"               value=""/>
+				<env key="VBOX_LOG_FLAGS"         value="thread"/>
+				<env key="VBOX_RELEASE_LOG_DEST"  value="file=/dev/log"/>
+				<env key="VBOX_RELEASE_LOG"       value=""/>
+				<env key="VBOX_RELEASE_LOG_FLAGS" value="thread"/>
+			</config>
+			<route>
+				<service name="Audio_out">                  <parent/>                       </service>
+				<service name="File_system" label="shared"> <parent label="shared"/>        </service>
+				<service name="File_system">                <parent label="vm"/>            </service>
+				<service name="ROM" label="usb_devices">    <parent label="usb_devices"/>   </service>
+				<service name="ROM" label="capslock">       <parent label="capslock"/>      </service>
+				<service name="ROM" label="platform_info">  <parent label="platform_info"/> </service>
+				<service name="ROM" label="VBoxSharedClipboard.so">
+				  <parent label="virtualbox6-sharedclipboard.lib.so"/> </service>
+				<service name="ROM" label="VBoxSharedFolders.so">
+				  <parent label="virtualbox6-sharedfolders.lib.so"/> </service>
+				<service name="ROM" label="mesa_gpu_drv.lib.so">
+				  <parent label="mesa_gpu_drv.lib.so"/> </service>
+				<service name="Nic">                        <parent/>                       </service>
+				<service name="Report" label="shape">       <parent label="shape"/>         </service>
+				<service name="ROM"    label="clipboard">   <parent label="clipboard"/>     </service>
+				<service name="Report" label="clipboard">   <parent label="clipboard"/>     </service>
+				<service name="Gui">                        <parent label=""/>              </service>
+				<any-service> <parent/> </any-service>
+			</route>
+		</start>
+	</config>
+
+	<content>
+		<rom label="egl.lib.so"/>
+		<rom label="expat.lib.so"/>
+		<rom label="glapi.lib.so"/>
+		<rom label="ld.lib.so"/>
+		<rom label="init"/>
+		<rom label="virtualbox6"/>
+		<rom label="jpeg.lib.so"/>
+		<rom label="libc.lib.so"/>
+		<rom label="libdrm.lib.so"/>
+		<rom label="libiconv.lib.so"/>
+		<rom label="libm.lib.so"/>
+		<rom label="libyuv.lib.so"/>
+		<rom label="mesa.lib.so"/>
+		<rom label="qemu-usb.lib.so"/>
+		<rom label="stdcxx.lib.so"/>
+		<rom label="vfs.lib.so"/>
+		<rom label="vfs_gpu.lib.so"/>
+		<rom label="vfs_oss.lib.so"/>
+		<rom label="vfs_pipe.lib.so"/>
+		<rom label="virtualbox6-shaderlib.lib.so"/>
+		<rom label="virtualbox6-sharedclipboard.lib.so"/>
+		<rom label="virtualbox6-sharedfolders.lib.so"/>
+		<rom label="zlib.lib.so"/>
+	</content>
+
+</runtime>

--- a/projects/t430/GENODE/depot/local/pkg/vbox6/2022-10-13/runtime
+++ b/projects/t430/GENODE/depot/local/pkg/vbox6/2022-10-13/runtime
@@ -1,4 +1,4 @@
-<runtime ram="4300M" caps="8000" binary="init">
+<runtime ram="4300M" caps="8000" binary="init" config="init.config">
 
 	<requires>
 		<file_system label="vm"/>
@@ -22,58 +22,6 @@
 		<audio_in/>
 	</requires>
 
-	<config verbose="yes">
-
-		<parent-provides>
-			<service name="ROM"/>
-			<service name="PD"/>
-			<service name="RM"/>
-			<service name="CPU"/>
-			<service name="LOG"/>
-			<service name="VM"/>
-			<service name="Gui"/>
-			<service name="Gpu"/>
-			<service name="Timer"/>
-			<service name="Rtc"/>
-			<service name="Report"/>
-			<service name="File_system"/>
-			<service name="Usb"/>
-			<service name="Nic"/>
-			<service name="Audio_out"/>
-			<service name="Audio_in"/>
-		</parent-provides>
-
-		<default-route> <any-service> <parent/> <any-child/> </any-service> </default-route>
-
-		<default caps="100"/>
-
-		<start name="vbox" caps="7000">
-			<binary name="virtualbox6" />
-			<resource name="RAM" quantum="8G"/>
-			<exit propagate="yes"/>
-			<config vbox_file="machine.vbox6" xhci="yes" vm_name="linux" capslock="rom" ld_verbose="yes">
-				<vfs>
-					<dir name="dev">
-						<log/> <rtc/> <null/> <gpu/> <zero/> <oss name="dsp"/>
-					</dir>
-					<dir name="pipe"> <pipe/> </dir>
-					<dir name="shared"> <fs label="shared" writeable="yes"/> </dir>
-					<rom name="VBoxSharedClipboard.so"/>
-					<rom name="VBoxSharedFolders.so"/>
-					<fs writeable="yes"/>
-				</vfs>
-				<libc stdout="/dev/log" stderr="/dev/log" rtc="/dev/rtc" pipe="/pipe">
-					<pthread placement="single-cpu"/>
-				</libc>
-				<arg value="virtualbox"/>
-				<env key="VBOX_USER_HOME" value="/"/>
-				<env key="VBOX_LOG_DEST"          value="file=/dev/log"/>
-				<env key="VBOX_LOG"               value=""/>
-				<env key="VBOX_LOG_FLAGS"         value="thread"/>
-				<env key="VBOX_RELEASE_LOG_DEST"  value="file=/dev/log"/>
-				<env key="VBOX_RELEASE_LOG"       value=""/>
-				<env key="VBOX_RELEASE_LOG_FLAGS" value="thread"/>
-			</config>
 			<route>
 				<service name="Audio_out">                  <parent/>                       </service>
 				<service name="File_system" label="shared"> <parent label="shared"/>        </service>

--- a/projects/t430/GENODE/depot/local/raw/vbox6/2022-04-27/init.config
+++ b/projects/t430/GENODE/depot/local/raw/vbox6/2022-04-27/init.config
@@ -1,0 +1,52 @@
+	<config verbose="yes">
+
+		<parent-provides>
+			<service name="ROM"/>
+			<service name="PD"/>
+			<service name="RM"/>
+			<service name="CPU"/>
+			<service name="LOG"/>
+			<service name="VM"/>
+			<service name="Gui"/>
+			<service name="Gpu"/>
+			<service name="Timer"/>
+			<service name="Rtc"/>
+			<service name="Report"/>
+			<service name="File_system"/>
+			<service name="Usb"/>
+			<service name="Nic"/>
+			<service name="Audio_out"/>
+			<service name="Audio_in"/>
+		</parent-provides>
+
+		<default-route> <any-service> <parent/> <any-child/> </any-service> </default-route>
+
+		<default caps="100"/>
+
+		<start name="vbox" caps="7000">
+			<binary name="virtualbox6" />
+			<resource name="RAM" quantum="8G"/>
+			<exit propagate="yes"/>
+			<config vbox_file="machine.vbox6" xhci="yes" vm_name="linux" capslock="rom" ld_verbose="yes">
+				<vfs>
+					<dir name="dev">
+						<log/> <rtc/> <null/> <gpu/> <zero/> <oss name="dsp"/>
+					</dir>
+					<dir name="pipe"> <pipe/> </dir>
+					<dir name="shared"> <fs label="shared" writeable="yes"/> </dir>
+					<rom name="VBoxSharedClipboard.so"/>
+					<rom name="VBoxSharedFolders.so"/>
+					<fs writeable="yes"/>
+				</vfs>
+				<libc stdout="/dev/log" stderr="/dev/log" rtc="/dev/rtc" pipe="/pipe">
+					<pthread placement="single-cpu"/>
+				</libc>
+				<arg value="virtualbox"/>
+				<env key="VBOX_USER_HOME" value="/"/>
+				<env key="VBOX_LOG_DEST"          value="file=/dev/log"/>
+				<env key="VBOX_LOG"               value=""/>
+				<env key="VBOX_LOG_FLAGS"         value="thread"/>
+				<env key="VBOX_RELEASE_LOG_DEST"  value="file=/dev/log"/>
+				<env key="VBOX_RELEASE_LOG"       value=""/>
+				<env key="VBOX_RELEASE_LOG_FLAGS" value="thread"/>
+			</config>

--- a/projects/t430/GENODE/depot/local/raw/vbox6/2022-04-27/init.config
+++ b/projects/t430/GENODE/depot/local/raw/vbox6/2022-04-27/init.config
@@ -12,6 +12,7 @@
 			<service name="Timer"/>
 			<service name="Rtc"/>
 			<service name="Report"/>
+			<service name="Block"/>
 			<service name="File_system"/>
 			<service name="Usb"/>
 			<service name="Nic"/>
@@ -31,6 +32,11 @@
 				<vfs>
 					<dir name="dev">
 						<log/> <rtc/> <null/> <gpu/> <zero/> <oss name="dsp"/>
+
+   <block name="sda1" label="1" block_buffer_count="128"/>
+   <block name="sda4" label="4" block_buffer_count="128"/>
+   <block name="sda5" label="5" block_buffer_count="128"/>
+   <block name="sda6" label="6" block_buffer_count="128"/>
 					</dir>
 					<dir name="pipe"> <pipe/> </dir>
 					<dir name="shared"> <fs label="shared" writeable="yes"/> </dir>

--- a/projects/t430/GENODE/depot/local/raw/vbox6/2022-04-27/machine.vbox6
+++ b/projects/t430/GENODE/depot/local/raw/vbox6/2022-04-27/machine.vbox6
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<VirtualBox xmlns="http://www.virtualbox.org/" version="1.18-genode">
+  <Machine uuid="{37ab43a5-38d8-4491-93f5-5b0b077f5c32}" name="ubuntu_16_04_64" OSType="Ubuntu_64" snapshotFolder="Snapshots" lastStateChange="2018-01-23T18:40:00Z">
+    <MediaRegistry>
+      <HardDisks>
+        <HardDisk uuid="{a90a16bf-f724-4321-99df-5498d6e4b796}" location="machine.vdi" format="VDI" type="Normal"/>
+      </HardDisks>
+      <DVDImages>
+        <Image uuid="{81763434-9a51-49e8-9444-528a5a28c4bc}" location="installer.iso"/>
+      </DVDImages>
+    </MediaRegistry>
+    <Hardware>
+      <CPU count="2">
+        <PAE enabled="true"/>
+        <LongMode enabled="true"/>
+        <HardwareVirtExLargePages enabled="false"/>
+      </CPU>
+      <Memory RAMSize="4096"/>
+      <HID Pointing="PS2Mouse"/>
+      <!-- normal operation -->
+      <Display VRAMSize="20" monitorCount="1" controller="VBoxSVGA"/>
+      <!-- 3D Linux
+      <Display controller="VMSVGA" VRAMSize="256" accelerate3D="true"/>
+      -->
+      <!-- 3D Windows
+      <Display VRAMSize="128" monitorCount="1" controller="VBoxSVGA" accelerate3D="true"/>
+      -->
+      <RemoteDisplay enabled="false"/>
+      <Paravirt provider="KVM"/>
+      <BIOS>
+        <IOAPIC enabled="true"/>
+      </BIOS>
+      <USB>
+        <Controllers>
+          <Controller name="OHCI" type="OHCI"/>
+        </Controllers>
+      </USB>
+      <Network>
+        <Adapter slot="0" enabled="true" MACAddress="0800271D7901" cable="true" type="82540EM">
+          <BridgedInterface/>
+        </Adapter>
+      </Network>
+      <UART>
+        <Port slot="0" enabled="false" IOBase="0x3f8" IRQ="4" hostMode="Disconnected"/>
+        <Port slot="1" enabled="false" IOBase="0x2f8" IRQ="3" hostMode="Disconnected"/>
+      </UART>
+      <LPT>
+        <Port slot="0" enabled="false" IOBase="0x378" IRQ="7"/>
+        <Port slot="1" enabled="false" IOBase="0x378" IRQ="7"/>
+      </LPT>
+      <AudioAdapter controller="HDA" driver="OSS" enabled="false" enabledIn="false" enabledOut="false"/>
+      <RTC localOrUTC="UTC"/>
+      <SharedFolders>
+        <SharedFolder name="shared" hostPath="/shared" writable="true" autoMount="true"/>
+      </SharedFolders>
+      <Clipboard mode="Bidirectional"/>
+    </Hardware>
+    <StorageControllers>
+      <StorageController name="SATA" type="AHCI" PortCount="4" useHostIOCache="true" Bootable="true" IDE0MasterEmulationPort="0" IDE0SlaveEmulationPort="1" IDE1MasterEmulationPort="2" IDE1SlaveEmulationPort="3">
+        <AttachedDevice type="HardDisk" port="0" device="0">
+          <Image uuid="{a90a16bf-f724-4321-99df-5498d6e4b796}"/>
+        </AttachedDevice>
+        <AttachedDevice passthrough="false" type="DVD" port="3" device="0">
+          <Image uuid="{81763434-9a51-49e8-9444-528a5a28c4bc}"/>
+        </AttachedDevice>
+      </StorageController>
+    </StorageControllers>
+  </Machine>
+</VirtualBox>

--- a/projects/t430/GENODE/vm/debian/machine.vbox6
+++ b/projects/t430/GENODE/vm/debian/machine.vbox6
@@ -3,10 +3,12 @@
   <Machine uuid="{37ab43a5-38d8-4491-93f5-5b0b077f5c32}" name="ubuntu_16_04_64" OSType="Ubuntu_64" snapshotFolder="Snapshots" lastStateChange="2018-01-23T18:40:00Z">
     <MediaRegistry>
       <HardDisks>
-        <HardDisk uuid="{0fc8be24-2365-43cd-bd86-9f3c6ed05f2b}" location="machine.vdi" format="VDI" type="Normal"/>
+        <HardDisk uuid="{9203178a-eafb-4060-aa3b-03ff4597d076}" location="linux.vmdk" format="VMDK" type="Normal"/>
       </HardDisks>
       <DVDImages>
+	<!--
         <Image uuid="{81763434-9a51-49e8-9444-528a5a28c4bc}" location="installer.iso"/>
+        -->
       </DVDImages>
     </MediaRegistry>
     <Hardware>
@@ -58,7 +60,7 @@
     <StorageControllers>
       <StorageController name="SATA" type="AHCI" PortCount="4" useHostIOCache="true" Bootable="true" IDE0MasterEmulationPort="0" IDE0SlaveEmulationPort="1" IDE1MasterEmulationPort="2" IDE1SlaveEmulationPort="3">
         <AttachedDevice type="HardDisk" port="0" device="0">
-          <Image uuid="{0fc8be24-2365-43cd-bd86-9f3c6ed05f2b}"/>
+          <Image uuid="{9203178a-eafb-4060-aa3b-03ff4597d076}"/>
         </AttachedDevice>
         <AttachedDevice passthrough="false" type="DVD" port="3" device="0">
           <Image uuid="{81763434-9a51-49e8-9444-528a5a28c4bc}"/>

--- a/projects/t430/Makefile
+++ b/projects/t430/Makefile
@@ -73,7 +73,9 @@ $(GENODE)/vm/debian/linux.vmdk: linux.vmdk
 
 # http://genodians.org/skalk/2019-03-18-hybrid-packages
 
-hybrid-packages: GENODE/depot/local/pkg/vbox6
+hybrid-packages: \
+	GENODE/depot/local/pkg/vbox6 \
+	$(GENODE)/depot/local/raw/vbox6/2022-04-27/init.config
 
 GENODE/depot/local/pkg/vbox6/2022-10-13/README: $(GENODE)/depot/local/pkg/vbox6/2022-10-13/README
 	mkdir -p GENODE/depot/local/pkg
@@ -82,6 +84,12 @@ GENODE/depot/local/pkg/vbox6/2022-10-13/README: $(GENODE)/depot/local/pkg/vbox6/
 	cp -r $(GENODE)/depot/genodelabs/raw/vbox6 GENODE/depot/local/raw/
 
 # Then you alter the configuration of the Virtualbox component in depot/local/raw/vbox5-nova-sculpt/{yyyy-mm-dd}/init.config
+
+$(GENODE)/depot/local/raw/vbox6/2022-04-27/init.config: GENODE/depot/local/raw/vbox6/2022-04-27/init.config
+	mkdir -p $(GENODE)/depot/local/pkg
+	mkdir -p $(GENODE)/depot/local/raw
+	cp -r GENODE/depot/local/raw/vbox6 $(GENODE)/depot/local/raw/vbox6
+	cp -r GENODE/depot/local/pkg/vbox6 $(GENODE)/depot/local/pkg/vbox6
 
 $(GENODE)/config/22.10/launcher/vm: GENODE/config/22.10/launcher/vm
 	cp $< $@

--- a/projects/t430/Makefile
+++ b/projects/t430/Makefile
@@ -64,11 +64,16 @@ vm-launcher: \
 # interfere with the partitions that are used by my Sculpt system, I
 # must prepare a special vmdk file:"
 
+vmdk: $(GENODE)/vm/debian/linux.vmdk $(GENODE)/vm/debian/linux-pt.vmdk
+
 linux.vmdk:
 	VBoxManage internalcommands createrawvmdk -filename linux.vmdk \
 	  -rawdisk /dev/sda -partitions 1,4,5,6 -relative
 
 $(GENODE)/vm/debian/linux.vmdk: linux.vmdk
+	cp $< $@
+
+$(GENODE)/vm/debian/linux-pt.vmdk: linux-pt.vmdk
 	cp $< $@
 
 # http://genodians.org/skalk/2019-03-18-hybrid-packages

--- a/projects/t430/Makefile
+++ b/projects/t430/Makefile
@@ -22,15 +22,18 @@ sda-sfdisk.json:
 #  - How to install a fresh VM on Sculpt
 #    October 27 2022 by Johannes Schlatow
 #    https://genodians.org/jschlatow/2022-10-27-fresh-vm-on-sculpt
+GENODE=/GENODE
 
 # Virtual Disk Image (vdi)
 #
 
 machine.vdi:
 	exit 1 # don't do this again
-	VBoxManage createmedium --filename /GENODE/vm/debian/machine.vdi \
+	VBoxManage createmedium --filename $(GENODE)/vm/debian/machine.vdi \
 	                          --size 10000 --variant Fixed
 
 # Note especially the UUID, for use in machine.vbox6
 machine.vdi.info:
-	VBoxManage showmediuminfo /GENODE/vm/debian/machine.vdi | tee $@
+	VBoxManage showmediuminfo $(GENODE)/vm/debian/machine.vdi | tee $@
+
+

--- a/projects/t430/Makefile
+++ b/projects/t430/Makefile
@@ -55,6 +55,11 @@ check-ahci:
 
 # usr/lib/modules/5.15.0-58-generic/kernel/drivers/ata/ahci.ko
 
+vm-launcher: \
+	$(GENODE)/config/22.10/launcher/vm \
+	$(GENODE)/vm/debian/machine.vbox6 \
+	$(GENODE)/vm/debian/linux.vmdk
+
 # "in order to make the system bootable with VirtualBox but not
 # interfere with the partitions that are used by my Sculpt system, I
 # must prepare a special vmdk file:"
@@ -76,9 +81,10 @@ GENODE/depot/local/pkg/vbox6/2022-10-13/README: $(GENODE)/depot/local/pkg/vbox6/
 	cp -r $(GENODE)/depot/genodelabs/pkg/vbox6 GENODE/depot/local/pkg/
 	cp -r $(GENODE)/depot/genodelabs/raw/vbox6 GENODE/depot/local/raw/
 
-vm-launcher: $(GENODE)/config/22.10/launcher/vm
+# Then you alter the configuration of the Virtualbox component in depot/local/raw/vbox5-nova-sculpt/{yyyy-mm-dd}/init.config
 
 $(GENODE)/config/22.10/launcher/vm: GENODE/config/22.10/launcher/vm
 	cp $< $@
 
-# Then you alter the configuration of the Virtualbox component in depot/local/raw/vbox5-nova-sculpt/{yyyy-mm-dd}/init.config
+$(GENODE)/vm/debian/machine.vbox6: GENODE/vm/debian/machine.vbox6
+	cp $< $@

--- a/projects/t430/Makefile
+++ b/projects/t430/Makefile
@@ -37,3 +37,32 @@ machine.vdi.info:
 	VBoxManage showmediuminfo $(GENODE)/vm/debian/machine.vdi | tee $@
 
 
+# legacy grub for booting in vbox
+# https://genodians.org/jschlatow/2021-04-23-start-existing-linux-from-sculpt
+
+legacy-grub:
+	grub-install --target=i386-pc --boot-directory=/boot /dev/sda
+	grub-mkconfig -o /boot/grub/grub.cfg
+
+# "If CONFIG_SATA_AHCI=m, make sure that your initramfs contains the
+# ahci module"
+check-ahci:
+	zgrep CONFIG_SATA_AHCI /boot/config-5.15.0-56-generic
+	lsinitramfs /boot/initrd.img | grep ahci
+
+# CONFIG_SATA_AHCI=m
+# CONFIG_SATA_AHCI_PLATFORM=m
+
+# usr/lib/modules/5.15.0-58-generic/kernel/drivers/ata/ahci.ko
+
+# "in order to make the system bootable with VirtualBox but not
+# interfere with the partitions that are used by my Sculpt system, I
+# must prepare a special vmdk file:"
+
+linux.vmdk:
+	VBoxManage internalcommands createrawvmdk -filename linux.vmdk \
+	  -rawdisk /dev/sda -partitions 1,4,5,6 -relative
+
+$(GENODE)/vm/debian/linux.vmdk: linux.vmdk
+	cp $< $@
+

--- a/projects/t430/Makefile
+++ b/projects/t430/Makefile
@@ -66,3 +66,15 @@ linux.vmdk:
 $(GENODE)/vm/debian/linux.vmdk: linux.vmdk
 	cp $< $@
 
+# http://genodians.org/skalk/2019-03-18-hybrid-packages
+
+hybrid-packages: GENODE/depot/local/pkg/vbox6
+
+GENODE/depot/local/pkg/vbox6:
+	mkdir -p GENODE/depot/local/pkg
+	mkdir -p GENODE/depot/local/raw
+	cp -r $(GENODE)/depot/genodelabs/pkg/vbox6 GENODE/depot/local/pkg/
+	cp -r $(GENODE)/depot/genodelabs/raw/vbox6 GENODE/depot/local/raw/
+
+# TODO:
+# Then you alter the configuration of the Virtualbox component in depot/local/raw/vbox5-nova-sculpt/{yyyy-mm-dd}/init.config

--- a/projects/t430/Makefile
+++ b/projects/t430/Makefile
@@ -70,11 +70,15 @@ $(GENODE)/vm/debian/linux.vmdk: linux.vmdk
 
 hybrid-packages: GENODE/depot/local/pkg/vbox6
 
-GENODE/depot/local/pkg/vbox6:
+GENODE/depot/local/pkg/vbox6/2022-10-13/README: $(GENODE)/depot/local/pkg/vbox6/2022-10-13/README
 	mkdir -p GENODE/depot/local/pkg
 	mkdir -p GENODE/depot/local/raw
 	cp -r $(GENODE)/depot/genodelabs/pkg/vbox6 GENODE/depot/local/pkg/
 	cp -r $(GENODE)/depot/genodelabs/raw/vbox6 GENODE/depot/local/raw/
 
-# TODO:
+vm-launcher: $(GENODE)/config/22.10/launcher/vm
+
+$(GENODE)/config/22.10/launcher/vm: GENODE/config/22.10/launcher/vm
+	cp $< $@
+
 # Then you alter the configuration of the Virtualbox component in depot/local/raw/vbox5-nova-sculpt/{yyyy-mm-dd}/init.config

--- a/projects/t430/linux.vmdk
+++ b/projects/t430/linux.vmdk
@@ -1,0 +1,29 @@
+# Disk DescriptorFile
+version=1
+CID=99416f54
+parentCID=ffffffff
+createType="partitionedDevice"
+
+# Extent description
+RW 63 FLAT "linux-pt.vmdk" 0
+RW 1985 ZERO 
+RW 2048 FLAT "/dev/sda1" 0
+RW 204800 ZERO 
+RW 20971520 ZERO 
+RW 52428800 FLAT "/dev/sda4" 0
+RW 134217728 FLAT "/dev/sda5" 0
+RW 42242703 FLAT "/dev/sda6" 0
+RW 33 FLAT "linux-pt.vmdk" 63
+
+# The disk Data Base 
+#DDB
+
+ddb.virtualHWVersion = "4"
+ddb.adapterType="ide"
+ddb.geometry.cylinders="16383"
+ddb.geometry.heads="16"
+ddb.geometry.sectors="63"
+ddb.uuid.image="9203178a-eafb-4060-aa3b-03ff4597d076"
+ddb.uuid.parent="00000000-0000-0000-0000-000000000000"
+ddb.uuid.modification="00000000-0000-0000-0000-000000000000"
+ddb.uuid.parentmodification="00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
- chore(t430): provided vbox6 pkg, raw
- chore(t430): parameterize extra-repo $(GENODE)
- feat(t430): legacy-grub, check-ahci, linux.vmdk
- chore(t430): prepare to make local vbox6 pkg
- chore(t430): move local vbox6 config from runtime to init.config
- chore(t430): point vbox6 package archives to local raw
- feat(t430): vm launcher using block device
- chore(t430): generated vmdk file
- chore(t430): point machine.vbox6 at linux.vmdk
- feat(t430): boot linux from vbox6 in genode
- fixup: deploy local packages
- fixup: linux-pt.vmdk too
